### PR TITLE
Fix the build on Ubuntu 24.04.

### DIFF
--- a/sdk/master_board_sdk/example/example.cpp
+++ b/sdk/master_board_sdk/example/example.cpp
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <chrono>
+#include <stdexcept>
 #include <math.h>
 #include <stdio.h>
 #include <sys/stat.h>

--- a/sdk/master_board_sdk/example/example_pd.cpp
+++ b/sdk/master_board_sdk/example/example_pd.cpp
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <chrono>
+#include <stdexcept>
 #include <math.h>
 #include <stdio.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Make sure to #include <stdexcept> where needed.

This should fix the build on Ubuntu 24.04, like https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__odri_master_board_sdk__ubuntu_noble_amd64__binary/13/console